### PR TITLE
Your gateway gave a 502, adding an extra gateway

### DIFF
--- a/public/js/player.js
+++ b/public/js/player.js
@@ -20,7 +20,8 @@ console.log(subs)
 		'http://127.0.0.1:8080', // User's own IPFS daemon
 		'', // Us
 		'https://gateway.ipfs.io', // Official gateway
-		'https://ipfs.pics' // Is this rude?
+		'https://ipfs.pics', // Is this rude?
+		'http://gw.ipfs.video'
 	];
 	var urls = sources.map(function(prefix) {
 		return prefix + hashToPath(hash);


### PR DESCRIPTION
Local ipfs was down, your gateway gave a 502 and both gateway.ipfs.io and ipfw.pics had problems with cross-origin policies.

I just stated a new gateway just to see how it works and to try it with a Kodi plugin I'm developing. Can't say it will be up forever, but it might help to add the gw anyway.